### PR TITLE
Quantiles

### DIFF
--- a/src/statistics.ts
+++ b/src/statistics.ts
@@ -12,14 +12,29 @@ export function mean(values: number[]) {
   return values.length ? total(values) / values.length : 0;
 }
 
-/** Calculates the median of an array of numbers. */
-export function median(values: number[]) {
+/** Calculates the quantile of an array of numbers for the cumulative
+ * probability p. This method excludes the median in calculation, i.e.
+ * `quantile((1, 2, 3, 4, 5), 0.25) === 2`
+ * @param p Cumultive probability, 0 <= p <= 1
+ */
+export function quantile(values: number[], p: number): number {
   const n = values.length;
   if (!n) return 0;
 
-  const sorted = values.slice(0).sort();
-  return (n % 2 === 1) ? sorted[Math.floor(n / 2)] :
-         (sorted[n / 2 - 1] + sorted[n / 2]) / 2;
+  const sorted = values.slice(0).sort((a, b) => (a - b));
+  if (p === 1) return sorted[n - 1];
+
+  const index = n * p;
+  if (Number.isInteger(index)) {
+    return (sorted[index - 1] + sorted[index]) / 2;
+  } else {
+    return sorted[Math.floor(index)];
+  }
+}
+
+/** Calculates the median of an array of numbers. */
+export function median(values: number[]) {
+  return quantile(values, 0.5);
 }
 
 /**

--- a/test/statistics-test.ts
+++ b/test/statistics-test.ts
@@ -1,0 +1,26 @@
+// =============================================================================
+// Fermat.js | Statistic Tests
+// (c) Mathigon
+// =============================================================================
+
+
+import * as tape from 'tape';
+import {quantile} from '../src/statistics';
+
+
+tape('quantile', (test) => {
+  test.equal(quantile([], 0.5), 0);
+
+  const evenPopulation = [1, 2, 3, 4, 5];
+  test.equal(quantile(evenPopulation, 0.25), 2);
+  test.equal(quantile(evenPopulation, 0.5), 3);
+  test.equal(quantile(evenPopulation, 0.75), 4);
+  test.equal(quantile(evenPopulation, 1), 5);
+
+  const oddPopulation = [1, 2, 3, 4, 5, 6];
+  test.equal(quantile(oddPopulation, 0.25), 2);
+  test.equal(quantile(oddPopulation, 0.5), 7 / 2);
+  test.equal(quantile(oddPopulation, 0.75), 5);
+  test.equal(quantile(oddPopulation, 1), 6);
+  test.end();
+});


### PR DESCRIPTION
Adds a new `quantile` function.

Uses the 'CDF method' for determining the correct quantiles as described in method 4 [here](https://www.tandfonline.com/doi/full/10.1080/10691898.2006.11910589). This is a 'median exclusive' approach - `quantile((1, 2, 3, 4, 5), 0.25) === 2`.