### PR TITLE
Fix simplified getter in Fraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mathigon/fermat",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "homepage": "https://mathigon.io/fermat",
   "repository": "mathigon/fermat.js",

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -5,7 +5,7 @@
 
 
 import {isInteger, nearlyEquals} from './arithmetic';
-import {lcm} from './number-theory';
+import {gcd} from './number-theory';
 
 
 /**  Fraction class. */
@@ -27,7 +27,7 @@ export class Fraction {
   get simplified() {
     const n = Math.abs(this.n);
     const d = Math.abs(this.d);
-    const factor = lcm(n, d);
+    const factor = gcd(n, d);
     return new Fraction(this.sign * n / factor, d / factor);
   }
 


### PR DESCRIPTION
The `simplified` getter was incorrectly using `lcm` instead of `gcd`; this fixes that.